### PR TITLE
Correct the version of example-celery/project.ini

### DIFF
--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,5 +1,5 @@
 [project]
-version = 0.2.6
+version = 1.0.0
 type = application
 name = celery-autoscale-demo
 


### PR DESCRIPTION
The project version is referenced as "1.0.0" everywhere in the cluster template, while it was defined as "0.2.6" in the project.ini. The mismatch caused error in creating a cluster of the example.